### PR TITLE
Add redirection to authenticated users when accessing the Sign In/Up page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,10 @@ class ApplicationController < ActionController::Base
         redirect_to(auth_sign_in_url(), status: :see_other)
         end
     end
+
+    def not_authenticated()
+        if signed_in()
+            redirect_to(user_url(get_user()), status: :see_other)
+        end
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,8 @@
 class SessionsController < ApplicationController
   def new()
+    if signed_in()
+        redirect_to(user_url(get_user()), status: :see_other)
+    end
     @user = User.new()
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,6 @@
 class SessionsController < ApplicationController
   def new()
-    if signed_in()
-        redirect_to(user_url(get_user()), status: :see_other)
-    end
+    not_authenticated()
     @user = User.new()
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,9 @@ class UsersController < ApplicationController
   end
 
   def new()
+    if signed_in()
+        redirect_to(user_url(get_user()), status: :see_other)
+    end
     @user = User.new()
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,9 +29,7 @@ class UsersController < ApplicationController
   end
 
   def new()
-    if signed_in()
-        redirect_to(user_url(get_user()), status: :see_other)
-    end
+    not_authenticated()
     @user = User.new()
   end
 


### PR DESCRIPTION
If a user is logged in, we should redirect them to the profile page instead of still giving them access to the sign in/up page. 4be47f0be048ab255005db4386af1f041e5e039a does that.
I refactored this functionality on 9eb2679415eb7276c167de3ce81d732cd61a3ccd.